### PR TITLE
Remove admin text from personal settings

### DIFF
--- a/templates/admin.php
+++ b/templates/admin.php
@@ -1,6 +1,8 @@
 <div class="section" id="apporder">
     <h2><?php p($l->t('App Order')) ?></h2>
-    <p><?php p($l->t('Set a default order for all users. This will be ignored, if the user has setup a custom order.')) ?></p>
+    <?php if($_['type'] === 'admin') { ?>
+    <p><?php p($l->t('Set a default order for all users. This will be ignored, if the user has setup a custom order.')); ?></p>
+    <?php } ?>
     <p><em><?php p($l->t('Drag the app icons to change their order.')); ?></em></p>
     <ul id="appsorter" data-type="<?php p($_['type']); ?>">
     <?php foreach($_['nav'] as $entry) { ?>


### PR DESCRIPTION
Remove the "Set a default order for all users. This will be ignored, if the user has setup a custom order." so it is only showed under admin page.