### PR TITLE
Remove link to apps in settings

### DIFF
--- a/css/apporder.css
+++ b/css/apporder.css
@@ -25,7 +25,7 @@
 	border-radius: 3px;
 }
 
-#appsorter a {
+#appsorter li p {
 	display: block;
 	float: left;
 	padding-bottom: 1px;

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -6,9 +6,9 @@
     <?php foreach($_['nav'] as $entry) { ?>
         <li>
             <img class="app-icon svg" alt="" src="<?php print_unescaped($entry['icon']); ?>">
-            <a href="<?php print_unescaped($entry['href']); ?>">
+            <p>
             <?php echo $entry['name']; ?>
-            </a>
+            </p>
         </li>
     <?php } ?>
     </ul>


### PR DESCRIPTION
Sometimes I accidentally click on an item when I wanted to drag it. And I can't see what the benefit of having the items as clickable links is.
I probably should have opened an issue to discuss this first. If you think it should behave like it already does just close this pull request :)