### PR TITLE
Remove unneeded border-radius vendor prefixes

### DIFF
--- a/css/apporder.css
+++ b/css/apporder.css
@@ -1,6 +1,6 @@
 #appsorter {
 	margin-top: 10px;
-	width:100%;
+	width: 100%;
 	max-width: 320px;
 }
 #appsorter li {
@@ -11,7 +11,7 @@
 #appsorter img {
 	width: 20px;
 	height: 20px;
-	margin:1px;
+	margin: 1px;
 	margin-right: 10px;
 	-webkit-filter: invert(1);
 	filter: invert(1);
@@ -25,8 +25,6 @@
 	width: 100%;
 	height: 20px;
 	margin-bottom: 2px;
-	-webkit-border-radius: 3px;
-	-moz-border-radius: 3px;
 	border-radius: 3px;
 }
 


### PR DESCRIPTION
makes CSS a bit smaller. (no need to include support for Firefox 3.6 or iOS 3.0) :-)
REF: https://caniuse.com/#feat=border-radius

(also add spacing for consistent formatting)