### PR TITLE
Fixes bug when only hidden is defined.

### DIFF
--- a/js/apporder.js
+++ b/js/apporder.js
@@ -42,7 +42,7 @@ $(function () {
 			hidden = [];
 		}
 
-		if (order.length === 0) {
+		if (order.length === 0 && hidden.length === 0) {
 			app_menu.css('opacity', '1');
 			return;
 		}


### PR DESCRIPTION
In app order, if you only modify the hidden checkbox without touching the order, then it doesn't work as expected.